### PR TITLE
Automate teacher editor sync

### DIFF
--- a/public/teacher.html
+++ b/public/teacher.html
@@ -12,7 +12,6 @@
     <button id="uploadBtn">Upload to Students</button>
     <hr>
     <textarea id="editor" rows="10" cols="60"></textarea><br>
-    <button id="sendEdit">Send Edit</button>
   </div>
 
   <script src="/socket.io/socket.io.js"></script>
@@ -21,7 +20,6 @@
     const fileInput = document.getElementById('fileInput');
     const uploadBtn = document.getElementById('uploadBtn');
     const editor = document.getElementById('editor');
-    const sendEdit = document.getElementById('sendEdit');
 
     uploadBtn.addEventListener('click', () => {
       const file = fileInput.files[0];
@@ -35,9 +33,9 @@
         });
     });
 
-    sendEdit.addEventListener('click', () => {
-      socket.emit('editText', editor.value);
-    });
+      editor.addEventListener("input", () => {
+        socket.emit("editText", editor.value);
+      });
 
     // Show incoming text in the editor for reference
     socket.on('newText', text => {


### PR DESCRIPTION
## Summary
- remove the `Send Edit` button from the teacher page
- push edits to students automatically as the teacher types

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_683f99bf4f9c8326b5b6d42889863b3e