### PR TITLE
Sync scroll and larger text

### DIFF
--- a/public/student.html
+++ b/public/student.html
@@ -19,6 +19,10 @@
     socket.on('newText', text => {
       display.textContent = text;
     });
+
+    socket.on('scroll', pos => {
+      window.scrollTo(0, pos);
+    });
   </script>
 </body>
 </html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -4,6 +4,7 @@ body {
   color: #333;
   margin: 0;
   padding: 20px;
+  font-size: 1.2em;
 }
 
 .container {
@@ -44,5 +45,15 @@ pre#display {
   border: 1px solid #ccc;
   padding: 10px;
   background-color: white;
+  font-size: 1.2em;
+}
+
+pre#editor {
+  white-space: pre-wrap;
+  border: 1px solid #ccc;
+  padding: 10px;
+  background-color: white;
+  min-height: 300px;
+  font-size: 1.2em;
 }
 

--- a/public/teacher.html
+++ b/public/teacher.html
@@ -10,7 +10,7 @@
     <h1>Teacher Console</h1>
     <input type="file" id="fileInput" accept=".txt">
     <hr>
-    <textarea id="editor" rows="10" cols="60"></textarea><br>
+    <pre id="editor" contenteditable="true"></pre>
   </div>
 
   <script src="/socket.io/socket.io.js"></script>
@@ -31,13 +31,17 @@
         });
     });
 
-      editor.addEventListener("input", () => {
-        socket.emit("editText", editor.value);
-      });
+    editor.addEventListener('input', () => {
+      socket.emit('editText', editor.textContent);
+    });
+
+    window.addEventListener('scroll', () => {
+      socket.emit('scroll', window.pageYOffset || document.documentElement.scrollTop);
+    });
 
     // Show incoming text in the editor for reference
     socket.on('newText', text => {
-      editor.value = text;
+      editor.textContent = text;
     });
   </script>
 </body>

--- a/server.js
+++ b/server.js
@@ -29,6 +29,10 @@ io.on('connection', socket => {
   socket.on('editText', newText => {
     io.emit('newText', newText);
   });
+
+  socket.on('scroll', pos => {
+    socket.broadcast.emit('scroll', pos);
+  });
 });
 
 const PORT = process.env.PORT || 3000;


### PR DESCRIPTION
## Summary
- display teacher text without a textarea and broadcast scroll position
- mirror teacher scroll on student page
- enlarge base font size and style editable area

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_683fad9d71b88326ab1013a1354d6674