### PR TITLE
Add close button for teacher menu

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -62,9 +62,26 @@ pre#editor {
   top: 10px;
   right: 10px;
   font-size: 24px;
-  background: none;
+  background-color: #007bff;
+  color: white;
   border: none;
+  padding: 8px 12px;
+  border-radius: 4px;
   cursor: pointer;
+  z-index: 1000;
+}
+
+.close-btn {
+  background-color: #dc3545;
+  color: white;
+  border: none;
+  padding: 4px 8px;
+  border-radius: 4px;
+  cursor: pointer;
+  float: right;
+  width: auto;
+  display: inline-block;
+  margin-bottom: 10px;
 }
 
 .menu {

--- a/public/teacher.html
+++ b/public/teacher.html
@@ -8,6 +8,7 @@
 <body>
   <button id="menuToggle" class="hamburger">&#9776;</button>
   <div id="menu" class="menu">
+    <button id="menuClose" class="close-btn">&times;</button>
     <input type="file" id="fileInput" accept=".txt">
     <button id="fontIncrease">A+</button>
     <button id="fontDecrease">A-</button>
@@ -25,6 +26,7 @@
     const editor = document.getElementById('editor');
     const menuToggle = document.getElementById('menuToggle');
     const menu = document.getElementById('menu');
+    const menuClose = document.getElementById('menuClose');
     const incBtn = document.getElementById('fontIncrease');
     const decBtn = document.getElementById('fontDecrease');
     let fontSize = parseFloat(getComputedStyle(editor).fontSize);
@@ -36,6 +38,10 @@
 
     menuToggle.addEventListener('click', () => {
       menu.classList.toggle('open');
+    });
+
+    menuClose.addEventListener('click', () => {
+      menu.classList.remove('open');
     });
 
     incBtn.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- make hamburger menu more visible
- add a close button inside the menu

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_683fb29e213c832697ac3d4b305eb30b