### PR TITLE
Fix highlight overlay line-height

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -46,6 +46,7 @@ pre#display {
   padding: 10px;
   background-color: white;
   font-size: 1.2em;
+  line-height: 1.4em;
 }
 
 pre#editor {
@@ -55,6 +56,7 @@ pre#editor {
   background-color: white;
   min-height: 300px;
   font-size: 1.2em;
+  line-height: 1.4em;
 }
 
 .editor-wrapper {


### PR DESCRIPTION
## Summary
- ensure editor and display `<pre>` tags specify `line-height`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_683fbb6024d883268ceeee677c3f5829