### PR TITLE
Highlight lines with spans

### DIFF
--- a/public/student.html
+++ b/public/student.html
@@ -10,7 +10,6 @@
     <h1>Book Reader</h1>
     <div id="displayWrapper" class="editor-wrapper">
       <pre id="display"></pre>
-      <div id="highlight" class="highlight-overlay" style="display:none;"></div>
     </div>
   </div>
 
@@ -18,19 +17,24 @@
   <script>
     const socket = io();
     const display = document.getElementById('display');
-    const highlight = document.getElementById('highlight');
     const wrapper = document.getElementById('displayWrapper');
     let highlightActive = false;
     let currentLine = 0;
 
+    function renderText(text) {
+      const lines = text.split('\n');
+      display.innerHTML = lines.map(l => `<span class="line">${l}</span>`).join('');
+    }
+
     function updateHighlight() {
-      const lineHeight = parseFloat(getComputedStyle(display).lineHeight);
-      highlight.style.height = lineHeight + 'px';
-      highlight.style.top = (currentLine * lineHeight) + 'px';
+      const lines = display.querySelectorAll('.line');
+      lines.forEach((line, idx) => {
+        line.classList.toggle('highlight-line', highlightActive && idx === currentLine);
+      });
     }
 
     socket.on('newText', text => {
-      display.textContent = text;
+      renderText(text);
       updateHighlight();
     });
 
@@ -46,7 +50,6 @@
     socket.on('highlightToggle', data => {
       highlightActive = data.active;
       currentLine = data.line;
-      highlight.style.display = highlightActive ? 'block' : 'none';
       updateHighlight();
     });
 

--- a/public/styles.css
+++ b/public/styles.css
@@ -63,13 +63,15 @@ pre#editor {
   position: relative;
 }
 
-.highlight-overlay {
-  position: absolute;
-  left: 0;
-  right: 0;
+
+.line {
+  display: block;
+  white-space: pre-wrap;
+}
+
+.line.highlight-line {
   background: yellow;
   opacity: 0.4;
-  pointer-events: none;
 }
 
 .hamburger {

--- a/public/teacher.html
+++ b/public/teacher.html
@@ -18,7 +18,6 @@
     <h1>Teacher Console</h1>
     <div id="editorWrapper" class="editor-wrapper">
       <pre id="editor" contenteditable="true"></pre>
-      <div id="highlight" class="highlight-overlay" style="display:none;"></div>
     </div>
   </div>
 
@@ -32,21 +31,25 @@
     const menuClose = document.getElementById('menuClose');
     const incBtn = document.getElementById('fontIncrease');
     const decBtn = document.getElementById('fontDecrease');
-    const highlight = document.getElementById('highlight');
     const wrapper = document.getElementById('editorWrapper');
     let highlightActive = false;
     let currentLine = 0;
     let fontSize = parseFloat(getComputedStyle(editor).fontSize);
 
+    function renderText(text) {
+      const lines = text.split('\n');
+      editor.innerHTML = lines.map(l => `<span class="line">${l}</span>`).join('');
+    }
+
     function updateHighlight() {
-      const lineHeight = parseFloat(getComputedStyle(editor).lineHeight);
-      highlight.style.height = lineHeight + 'px';
-      highlight.style.top = (currentLine * lineHeight) + 'px';
+      const lines = editor.querySelectorAll('.line');
+      lines.forEach((line, idx) => {
+        line.classList.toggle('highlight-line', highlightActive && idx === currentLine);
+      });
     }
 
     function toggleHighlight() {
       highlightActive = !highlightActive;
-      highlight.style.display = highlightActive ? 'block' : 'none';
       const lineHeight = parseFloat(getComputedStyle(editor).lineHeight);
       const offsetTop = wrapper.getBoundingClientRect().top + (window.pageYOffset || document.documentElement.scrollTop);
       currentLine = Math.floor(((window.pageYOffset || document.documentElement.scrollTop) - offsetTop) / lineHeight);
@@ -133,14 +136,13 @@
 
     // Show incoming text in the editor for reference
     socket.on('newText', text => {
-      editor.textContent = text;
+      renderText(text);
       updateHighlight();
     });
 
     socket.on('highlightToggle', data => {
       highlightActive = data.active;
       currentLine = data.line;
-      highlight.style.display = highlightActive ? 'block' : 'none';
       updateHighlight();
     });
 


### PR DESCRIPTION
## Summary
- render text as spans for each line
- track highlighting via span classes instead of overlay

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68883e226adc83268c3bc4c5bc6123e9