### PR TITLE
Improve highlight styling and auto-scrolling

### DIFF
--- a/public/student.html
+++ b/public/student.html
@@ -21,8 +21,23 @@
     let highlightActive = false;
     let currentLine = 0;
 
+    function breakIntoLines(text, maxChars) {
+      const out = [];
+      text.split('\n').forEach(line => {
+        if (line === '') { out.push(''); return; }
+        while (line.length > maxChars) {
+          out.push(line.slice(0, maxChars));
+          line = line.slice(maxChars);
+        }
+        out.push(line);
+      });
+      return out;
+    }
+
     function renderText(text) {
-      const lines = text.split('\n');
+      const charWidth = parseFloat(getComputedStyle(display).fontSize) * 0.6;
+      const maxChars = Math.max(1, Math.floor(display.clientWidth / charWidth));
+      const lines = breakIntoLines(text, maxChars);
       display.innerHTML = lines.map(l => `<span class="line">${l}</span>`).join('');
     }
 
@@ -33,9 +48,22 @@
       });
     }
 
+    function ensureHighlightInView() {
+      if (!highlightActive) return;
+      const lineHeight = parseFloat(getComputedStyle(display).lineHeight);
+      const offsetTop = wrapper.getBoundingClientRect().top + (window.pageYOffset || document.documentElement.scrollTop);
+      const highlightTop = currentLine * lineHeight + offsetTop;
+      if (highlightTop + lineHeight > (window.pageYOffset || document.documentElement.scrollTop) + window.innerHeight) {
+        window.scrollTo(0, highlightTop + lineHeight - window.innerHeight);
+      } else if (highlightTop < (window.pageYOffset || document.documentElement.scrollTop)) {
+        window.scrollTo(0, highlightTop);
+      }
+    }
+
     socket.on('newText', text => {
       renderText(text);
       updateHighlight();
+      ensureHighlightInView();
     });
 
     socket.on('scroll', pos => {
@@ -45,17 +73,20 @@
     socket.on('fontSize', size => {
       display.style.fontSize = size + 'px';
       updateHighlight();
+      ensureHighlightInView();
     });
 
     socket.on('highlightToggle', data => {
       highlightActive = data.active;
       currentLine = data.line;
       updateHighlight();
+      ensureHighlightInView();
     });
 
     socket.on('highlightMove', line => {
       currentLine = line;
       updateHighlight();
+      ensureHighlightInView();
     });
 
   </script>

--- a/public/styles.css
+++ b/public/styles.css
@@ -70,8 +70,8 @@ pre#editor {
 }
 
 .line.highlight-line {
-  background: yellow;
-  opacity: 0.4;
+  background: rgba(255, 255, 0, 0.4);
+  color: #000;
 }
 
 .hamburger {

--- a/public/teacher.html
+++ b/public/teacher.html
@@ -36,8 +36,23 @@
     let currentLine = 0;
     let fontSize = parseFloat(getComputedStyle(editor).fontSize);
 
+    function breakIntoLines(text, maxChars) {
+      const out = [];
+      text.split('\n').forEach(line => {
+        if (line === '') { out.push(''); return; }
+        while (line.length > maxChars) {
+          out.push(line.slice(0, maxChars));
+          line = line.slice(maxChars);
+        }
+        out.push(line);
+      });
+      return out;
+    }
+
     function renderText(text) {
-      const lines = text.split('\n');
+      const charWidth = parseFloat(getComputedStyle(editor).fontSize) * 0.6;
+      const maxChars = Math.max(1, Math.floor(editor.clientWidth / charWidth));
+      const lines = breakIntoLines(text, maxChars);
       editor.innerHTML = lines.map(l => `<span class="line">${l}</span>`).join('');
     }
 
@@ -48,18 +63,8 @@
       });
     }
 
-    function toggleHighlight() {
-      highlightActive = !highlightActive;
-      const lineHeight = parseFloat(getComputedStyle(editor).lineHeight);
-      const offsetTop = wrapper.getBoundingClientRect().top + (window.pageYOffset || document.documentElement.scrollTop);
-      currentLine = Math.floor(((window.pageYOffset || document.documentElement.scrollTop) - offsetTop) / lineHeight);
-      updateHighlight();
-      socket.emit('highlightToggle', { active: highlightActive, line: currentLine });
-    }
-
-    function moveHighlight(delta) {
+    function ensureHighlightInView() {
       if (!highlightActive) return;
-      currentLine = Math.max(0, currentLine + delta);
       const lineHeight = parseFloat(getComputedStyle(editor).lineHeight);
       const offsetTop = wrapper.getBoundingClientRect().top + (window.pageYOffset || document.documentElement.scrollTop);
       const highlightTop = currentLine * lineHeight + offsetTop;
@@ -68,7 +73,23 @@
       } else if (highlightTop < (window.pageYOffset || document.documentElement.scrollTop)) {
         window.scrollTo(0, highlightTop);
       }
+    }
+
+    function toggleHighlight() {
+      highlightActive = !highlightActive;
+      const lineHeight = parseFloat(getComputedStyle(editor).lineHeight);
+      const offsetTop = wrapper.getBoundingClientRect().top + (window.pageYOffset || document.documentElement.scrollTop);
+      currentLine = Math.floor(((window.pageYOffset || document.documentElement.scrollTop) - offsetTop) / lineHeight);
       updateHighlight();
+      ensureHighlightInView();
+      socket.emit('highlightToggle', { active: highlightActive, line: currentLine });
+    }
+
+    function moveHighlight(delta) {
+      if (!highlightActive) return;
+      currentLine = Math.max(0, currentLine + delta);
+      updateHighlight();
+      ensureHighlightInView();
       socket.emit('highlightMove', currentLine);
     }
 
@@ -112,6 +133,7 @@
       fontSize = size;
       editor.style.fontSize = size + 'px';
       updateHighlight();
+      ensureHighlightInView();
     });
 
     fileInput.addEventListener('change', () => {
@@ -138,17 +160,20 @@
     socket.on('newText', text => {
       renderText(text);
       updateHighlight();
+      ensureHighlightInView();
     });
 
     socket.on('highlightToggle', data => {
       highlightActive = data.active;
       currentLine = data.line;
       updateHighlight();
+      ensureHighlightInView();
     });
 
     socket.on('highlightMove', line => {
       currentLine = line;
       updateHighlight();
+      ensureHighlightInView();
     });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- keep highlighted text readable by setting text color to black
- wrap incoming text to page width and ensure highlight is visible for teacher and student views
- add automatic scrolling when highlight moves off-screen

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6888422217648326a366d55639099606